### PR TITLE
Removes compile time warning about the resolver

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -18,3 +18,6 @@ search_engine = { path = "../libs/search-engine" }
 task_runners = { path = "../libs/task-runners" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt-multi-thread"], default-features = false }
 www = { path = "../libs/www" }
+
+[workspace]
+resolver = "2"


### PR DESCRIPTION
Edition 2021 implies that the resolver should be "2" but is default "1",  on my NixOS system at least. This quick fix removes the warning and things work as expected when running cargo thereafter.